### PR TITLE
mmlicense: do not check against "requiredLicense" field

### DIFF
--- a/library/mmlicense.py
+++ b/library/mmlicense.py
@@ -50,23 +50,12 @@ def main():
 
     for row in mmls_xsv:
         if row['nodeName'] == node:
-            current['required'] = row['requiredLicense']
             current['designated'] = row['designatedLicense']
             break
 
     if not current:
         module.fail_json(
             msg="node %s not known by mmlslicense" % node,
-            mmlslicense=mmls,
-        )
-
-    if lic != current['required']:
-        module.fail_json(
-            msg="%s target %s license does not match required %s license" % (
-                node,
-                lic,
-                current['required']
-            ),
             mmlslicense=mmls,
         )
 


### PR DESCRIPTION
When a new node is added for the first time to GPFS (without specifying a license on mmaddnode), the Host probably gets assigned the "client" license by default.
Now if you want to designate the Host as a server afterwards, this check would prevent you to do so, since by default the "requiredLicense" is set to "client".
This check isn't really needed anyway, because I assume one can just treat the "requiredLicense" field in mmlslicense as a "hint". The only thing that matters is the designatedLicense.

Additionally, GPFS will somehow anyway rewrite this internally at some point. Recently added a new node and designated it as "server". mmslicense shows "client" for "requiredLicense" and "server" for "designatedLicense" as expected. Some time later, mmlslicense showed "server" as "requiredLicense", and "fpo-server" for "designatedLicense".

/cc @wookietreiber 